### PR TITLE
Support for IE8 - objection dot notation

### DIFF
--- a/jquery.charactercounter.js
+++ b/jquery.charactercounter.js
@@ -63,9 +63,9 @@
         {
             var classString = options.counterCssClass;
 
-            if ( options.customFields.class )
+            if ( options.customFields['class'] )
             {
-                classString += " " + options.customFields.class;
+                classString += " " + options.customFields['class'];
                 delete options.customFields['class'];
             }
 


### PR DESCRIPTION
Unfortunately IE8 freaks out and blows up when using dot notation on some object properties.  It will blow up here even if no customFields are used.  This is an easy, universally compatible fix.