### PR TITLE
Support for per-field limits

### DIFF
--- a/jquery.charactercounter.js
+++ b/jquery.charactercounter.js
@@ -1,5 +1,5 @@
 /**
- * Character Counter v1.5.1
+ * Character Counter v1.5.2
  * ======================
  *
  * Character Counter is a simple, Twitter style character counter.
@@ -69,16 +69,16 @@
                 delete options.customFields['class'];
             }
 
-            return '<'+ options.counterWrapper +customFields(options.customFields)+' class="' + classString + '"></'+ options.counterWrapper +'>';
+            return '<'+ options.counterWrapper +customFields(options.customFields)+' class="' + classString + '"' + ' data-limit="' + options.limit + '"' + '></'+ options.counterWrapper +'>';
         }
 
-        function renderText(count)
+        function renderText(count, limit)
         {
             var rendered_count = options.counterFormat.replace(/%1/, count);
 
             if ( options.renderTotal )
             {
-                rendered_count += '/'+ options.limit;
+                rendered_count += '/'+ (limit !== undefined ? limit : options.limit);
             }
 
             return rendered_count;
@@ -88,13 +88,14 @@
         {
             var characterCount = $(element).val().length;
             var counter = options.counterSelector ? $(options.counterSelector) : $(element).nextAll("." + options.counterCssClass).first();
-            var remaining = options.limit - characterCount;
+            var counterLimit = counter.attr('data-limit');
+            var remaining = counterLimit - characterCount;
             var condition = remaining < 0;
 
             if ( options.increaseCounting )
             {
                 remaining = characterCount;
-                condition = remaining > options.limit;
+                condition = remaining > counterLimit;
             }
 
             if ( condition )
@@ -112,7 +113,7 @@
                 }
             }
 
-            counter.html(renderText(remaining));
+            counter.html(renderText(remaining, counterLimit));
         }
 
         function bindEvents(element)


### PR DESCRIPTION
If adding a counter to multiple fields, with each having a different maxlength, the limit on the last counter on the page will be used for all other counters. This stores the limit on the respective counter instead.